### PR TITLE
Added an use section

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,10 @@ Similar to the BASH client you can configure posh-gvm to automatically set new i
 
 in your profile.
 
+## Use
+Replace `sdkman` for `gvm` and you'll have access to all the commands that you see in in the (GVM Tool homepage, now called sdkman)[http://sdkman.io/usage.html]
+
+
 ## Uninstall
 If you want to remove posh-gvm you need to perform 3 steps:
 


### PR DESCRIPTION
Currently, the project GVM is called sdkman. After installing GVM I wasn't able to understand how to use it as all documentation was linking to sdkman and obviously non of the commands were working.
With the new `use` section I think it will help people to start using this tool faster.