### PR TITLE
Explecetely change sdkman for gvm

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,10 @@ Similar to the BASH client you can configure posh-gvm to automatically set new i
 
 in your profile.
 
+## Use
+Replace `sdkman` for `gvm` and you'll have access to all the commands that you see in in the (GVM Tool homepage, now called sdkman)[http://sdkman.io/usage.html]
+
+
 ## Uninstall
 If you want to remove posh-gvm you need to perform 3 steps:
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Go to the checkout location and pull the repository.
 
 ## Usage
 
-For a general overview of the feature please the [GVM Project Page](http://gvmtool.net) because posh-gvm is designed to work like the original BASH client.
+For a general overview of the feature please the [GVM Project Page](http://gvmtool.net) because posh-gvm is designed to work like the original BASH client. Just replace `sdkman` for `gvm` and you'll have access to all the commands that you see in in the (GVM Tool homepage, now called sdkman)[http://sdkman.io/usage.html].
 
 Add `Import-Module posh-gvm` to your powershell profile to be able to use it after each start of Powershell. If you do not know where your profile is located, execute `$Global:profile`.
 


### PR DESCRIPTION
As a new user, I was very confused when the linked documentation was telling me to run `sdkman` commands. I hope that when explicitly stating that `sdkman` should be changed for gvm it will help new comers. 
